### PR TITLE
Update install_dependencies.yml to correct CentOS yum repo URLs

### DIFF
--- a/tasks/base/CentOS-8/install_dependencies.yml
+++ b/tasks/base/CentOS-8/install_dependencies.yml
@@ -14,7 +14,7 @@
     - replace:
         path: "{{ item.path }}"
         regexp: '#baseurl=http://mirror\.centos\.org'
-        replace: 'baseurl=http://vault.centos.org'
+        replace: 'baseurl=http://mirror.centos.org'
       with_items: "{{ repos.files }}"
 
 - name: Install base dependencies


### PR DESCRIPTION
CentOS yum repo URLs have changed back to mirror.centos.org.